### PR TITLE
Updating print statement for Python3 compatibility.

### DIFF
--- a/tribits/ci_support/clone_extra_repos.py
+++ b/tribits/ci_support/clone_extra_repos.py
@@ -436,7 +436,7 @@ def cloneExtraRepo(inOptions, extraRepoDict):
             "' already exists.  Skipping clone!")
     return
   if not repoVcType in commandMap:
-    print "\n  ==> ERROR: Repo type '"+repoVcType+"' not supported!"
+    print("\n  ==> ERROR: Repo type '"+repoVcType+"' not supported!")
     sys.exit(1)
   cmnd = commandMap[repoVcType]+" "+repoUrl+" "+repoDir
   if inOptions.doOp:


### PR DESCRIPTION
Quick fix for a print statement in the `clone_extra_repos.py` script.